### PR TITLE
Added Aditional Instructio For Installatioion In Ubuntu

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Bluetooth: hci1: BCM: Patch brcm/BCM20702A1-0b05-17cb.hcd not found
 
 As you can see, you need `brcm/BCM20702A1-0b05-17cb.hcd` firmware.
 
-Place required `.hcd` file to `/lib/firmware/brcm` and reboot your computer. After reboot
+Place required `.hcd` file to `/lib/firmware/brcm`,rename it to BCM.hcd and reboot your computer. After reboot
+Example cp BCM20702A1-0b05-17cbh.hcd /lib/firmware/brcm/BCM.hcd
 you will see that firmware successfully loaded:
 
 ```


### PR DESCRIPTION
In latest installation of ubuntu default name of driver not working . We have to rename it to BCM.hcd